### PR TITLE
Add Referer header to make it work on KP-9000-9XHML-X

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,6 +217,7 @@ func fetchPortStatistics(config Config) (PortStatistics, error) {
 	cookieValue := getMD5Hash(config.Username + config.Password)
 	req.AddCookie(&http.Cookie{Name: "admin", Value: cookieValue})
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Referer", fmt.Sprintf("http://%s/menu.cgi", config.Address))
 	req.URL.RawQuery = params.Encode()
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
This PR adds a Referer header to HTTP requests sent to the switch web interface.
Some models, such as the Keeplink KP-9000-9XHML-X, require a valid Referer header (http://<address>/menu.cgi) for authenticated requests to succeed.

Without this header, the switch rejects the request or returns incomplete data on the /port.cgi?page=stats endpoint.