### PR TITLE
Configurable port & config file location

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -20,6 +21,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	configFile = flag.String("config-file", "config.yaml", "config file to load")
 )
 
 type Config struct {
@@ -266,7 +271,8 @@ func (c *PortStatsCollector) Collect(ch chan<- prometheus.Metric) {
 
 func main() {
 	// Read configuration
-	config, err := readConfig("config.yaml")
+	flag.Parse()
+	config, err := readConfig(*configFile)
 	if err != nil {
 		log.Fatalf("Error reading configuration: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 
 var (
 	configFile = flag.String("config-file", "config.yaml", "config file to load")
+	port       = flag.String("port", ":8080", "port number to listen on")
 )
 
 type Config struct {
@@ -297,8 +298,8 @@ func main() {
 	// Start Prometheus HTTP server
 	http.Handle("/metrics", promhttp.Handler())
 	go func() {
-		log.Println("Starting Prometheus exporter on: 8080/metrics")
-		if err := http.ListenAndServe(":8080", nil); err != nil {
+		log.Printf("Starting Prometheus exporter on: %s/metrics", *port)
+		if err := http.ListenAndServe(*port, nil); err != nil {
 			log.Fatalf("HTTP server error: %v", err)
 		}
 	}()


### PR DESCRIPTION
e.g. `./cheap-switch-exporter -config-file /path/to/config.yml -port :9334`
Also adds help flag:
```
% ./cheap-switch-exporter -h
Usage of ./cheap-switch-exporter:
  -config-file string
        config file to load (default "config.yaml")
  -port string
        port number to listen on (default ":8080")
```